### PR TITLE
Lib : Fix the offset apply during `CalculatePearlTrace` will overwrite `Data` original position

### DIFF
--- a/PearlCalculatorLib/General/Calculation.cs
+++ b/PearlCalculatorLib/General/Calculation.cs
@@ -124,7 +124,7 @@ namespace PearlCalculatorLib.General
         public static List<Entity> CalculatePearlTrace(int redTNT , int blueTNT , int ticks , Direction direction)
         {
             List<Entity> result = new List<Entity>(ticks + 1);
-            PearlEntity pearl = new PearlEntity(Data.Pearl.AddPosition(Data.PearlOffset));
+            PearlEntity pearl = new PearlEntity(Data.Pearl).AddPosition(Data.PearlOffset);
             
             CalculateTNTVector(direction , out Space3D redTNTVector , out Space3D blueTNTVector);
             pearl.Motion += redTNT * redTNTVector + blueTNT * blueTNTVector;


### PR DESCRIPTION
Check the [line](https://github.com/LegendsOfSky/PearlCalculatorCore/blob/main/PearlCalculatorLib/General/Calculation.cs#L127C13-L127C25), it should first create the object first then apply the offset.